### PR TITLE
remove global monkey patching of Math.random when seeded

### DIFF
--- a/src/generate/dungeon.ts
+++ b/src/generate/dungeon.ts
@@ -10,7 +10,7 @@ import {
   TileMap,
   TreeNode,
 } from "./types";
-import { createTilemap, duplicateTilemap, random, randomChoice } from "./utils";
+import { createTilemap, duplicateTilemap, random, randomChoice, randomOptions } from "./utils";
 import seedrandom from "seedrandom";
 
 export interface DungeonArgs {
@@ -49,9 +49,8 @@ export interface Dungeon {
 
 export function generate(args: DungeonArgs): Dungeon {
   // If a seed is provided, use it to generate dungeon.
-  if (args.seed) {
-    seedrandom(args.seed, { global: true });
-  }
+  randomOptions.seed = args.seed || null;
+  randomOptions.random = args.seed ? seedrandom(args.seed) : Math.random;
 
   const startAt = Date.now();
 

--- a/src/generate/utils.ts
+++ b/src/generate/utils.ts
@@ -1,6 +1,25 @@
 import { TileMap } from "./types";
 
 /**
+ * An object containing random options that can be customized.
+ */
+export interface RandomOptions {
+  /**
+   * The seed used for generating random values.
+   */
+  seed: string | null;
+  random(): number;
+}
+
+/**
+ * Singleton configuration object for generating random options.
+ */
+export const randomOptions: RandomOptions = {
+  seed: null,
+  random: Math.random
+};
+
+/**
  * Create an empty tilemap.
  */
 export function createTilemap(
@@ -53,7 +72,7 @@ export function shuffleArray<T>(array: T[]): T[] {
   const newArray = [...array];
 
   for (let i = newArray.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(randomOptions.random() * (i + 1));
     [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
   }
 
@@ -64,14 +83,14 @@ export function shuffleArray<T>(array: T[]): T[] {
  * Generate a random number between `min` and `max`.
  */
 export function random(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1) + min);
+  return Math.floor(randomOptions.random() * (max - min + 1) + min);
 }
 
 /**
  * Return one of the values matching the randomly selected weight.
  */
 export function randomWeights<T>(weights: number[], values: T[]): T {
-  const num = Math.random();
+  const num = randomOptions.random();
   let s = 0;
   let lastIndex = weights.length - 1;
 
@@ -89,14 +108,14 @@ export function randomWeights<T>(weights: number[], values: T[]): T {
  * Return one of the values.
  */
 export function randomChoice<T>(values: T[]): T {
-  return values[Math.floor(Math.random() * values.length)];
+  return values[Math.floor(randomOptions.random() * values.length)];
 }
 
 /**
  * Return `true` if probability is matched.
  */
 export function randomProbability(probability: number): boolean {
-  return Math.random() > 1 - probability;
+  return randomOptions.random() > 1 - probability;
 }
 
 /**


### PR DESCRIPTION
This is a fix for issue #2 where the global Math.random is monkey patched after calling dungeon.generate with a seed. 